### PR TITLE
Fix the function for Pro Tree

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -131,9 +131,9 @@ def create_tree_v2(
 
 @on_document_created(
     document="users/{userId}/proTrees/{proTreeId}",
-    memory=MemoryOption.MB_1024,
+    memory=MemoryOption.GB_1,
 )
-def process_user_tree(event: Event[DocumentSnapshot | None]) -> None:
+def process_user_pro_tree(event: Event[DocumentSnapshot | None]) -> None:
     create_tree_v2(event, max_size_megabytes=100)
 
 


### PR DESCRIPTION
### Description

The `MemoryOption` property was adjusted since the value `MB_1024` does not belong to the **enum** expected by **firabase** and also the name of the function that will process the Pro Trees was changed.